### PR TITLE
Fix Swift Package Build

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/ibrahimcetin/libgit2.git", from: "1.8.0"),
+        .package(url: "https://github.com/ibrahimcetin/libgit2.git", exact: "1.8.0"),
         .package(url: "https://github.com/realm/SwiftLint.git", from: "0.54.0"),
         .package(url: "https://github.com/nicklockwood/SwiftFormat.git", from: "0.53.0"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.3.0")


### PR DESCRIPTION
Looks like SwiftGitX 0.1.7 pulls down your latest libgit2 fork release, [1.9.1](https://github.com/ibrahimcetin/libgit2/tree/1.9.1) instead of [1.8.0](https://github.com/ibrahimcetin/libgit2/releases/tag/1.8.0) because the dependency rule in `Package.swift` will choose the latest release of your libgit2 fork.

This creates build errors for lines 30 and 31 in `ObjectType.swift` where the `git_object_t` enum values cannot be found for `GIT_OBJECT_OFS_DELTA` and `GIT_OBJECT_REF_DELTA`.

https://github.com/ibrahimcetin/SwiftGitX/blob/e190291c8b8ff5732feb3c75348ce3c680df2210/Sources/SwiftGitX/Models/Types/ObjectType.swift#L30-L31

Setting the dependency to pull the exact version fixes the issue.
Maybe we should also pull exact versions for all the other versions too to prevent potential issues in the future?

Also sorry for the extra merge commit in this PR. I made the change on GitHub.com real quick and did it kind of hacky haha.

Thanks for your awesome library! :)