### PR TITLE
Rename SwiftGitX enum to SwiftGitXRuntime

### DIFF
--- a/Sources/SwiftGitX/SwiftGitX.swift
+++ b/Sources/SwiftGitX/SwiftGitX.swift
@@ -8,7 +8,7 @@
 import libgit2
 
 /// The main entry point for the SwiftGitX library.
-public enum SwiftGitX {
+public enum SwiftGitXRuntime {
     /// Initialize the SwiftGitX
     ///
     /// - Returns: the number of initializations of the library.

--- a/Tests/SwiftGitXTests/SwiftGitXTests.swift
+++ b/Tests/SwiftGitXTests/SwiftGitXTests.swift
@@ -11,12 +11,12 @@ class SwiftGitXTestCase: XCTestCase {
         super.setUp()
 
         // Initialize the SwiftGitX library
-        XCTAssertNoThrow(try SwiftGitX.initialize())
+        XCTAssertNoThrow(try SwiftGitXRuntime.initialize())
     }
 
     override class func tearDown() {
         // Shutdown the SwiftGitX library
-        XCTAssertNoThrow(try SwiftGitX.shutdown())
+        XCTAssertNoThrow(try SwiftGitXRuntime.shutdown())
 
         // Remove the temporary directory for the tests
         try? FileManager.default.removeItem(at: Repository.testsDirectory.appending(component: directory))
@@ -34,11 +34,11 @@ class SwiftGitXTest {
     }
 
     init() throws {
-        try SwiftGitX.initialize()
+        try SwiftGitXRuntime.initialize()
     }
 
     deinit {
-        _ = try? SwiftGitX.shutdown()
+        _ = try? SwiftGitXRuntime.shutdown()
     }
 }
 
@@ -48,7 +48,7 @@ struct SwiftGitXTests {
     @Test("Test SwiftGitX Initialize")
     func testSwiftGitXInitialize() async throws {
         // Initialize the SwiftGitX library
-        let count = try SwiftGitX.initialize()
+        let count = try SwiftGitXRuntime.initialize()
 
         // Check if the initialization count is valid
         #expect(count > 0)
@@ -57,7 +57,7 @@ struct SwiftGitXTests {
     @Test("Test SwiftGitX Shutdown")
     func testSwiftGitXShutdown() async throws {
         // Shutdown the SwiftGitX library
-        let count = try SwiftGitX.shutdown()
+        let count = try SwiftGitXRuntime.shutdown()
 
         // Check if the shutdown count is valid
         #expect(count >= 0)
@@ -67,7 +67,7 @@ struct SwiftGitXTests {
     func testSwiftGitXShutdownWithoutInitialize() async throws {
         // Shutdown the SwiftGitX library
         let result = #expect(throws: SwiftGitXError.self) {
-            try SwiftGitX.shutdown()
+            try SwiftGitXRuntime.shutdown()
         }
 
         let error = try #require(result)
@@ -89,7 +89,7 @@ struct SwiftGitXTests {
     @Test("Test SwiftGitX Version")
     func testVersion() throws {
         // Get the libgit2 version
-        let version = SwiftGitX.libgit2Version
+        let version = SwiftGitXRuntime.libgit2Version
 
         // Check if the version is valid
         #expect(version == "1.9.0")


### PR DESCRIPTION
### Problem
The `SwiftGitX` enum name conflicts with the module name, making it impossible to reference module-level types when the enum is in scope. This particularly affects tests using Swift Testing where `Testing.Tag` and `SwiftGitX.Tag` create ambiguity.

Before - Ambiguous, doesn't work
```swift
let tag = try #require(references.first as? SwiftGitX.Tag)
// Error: SwiftGitX.Tag resolves to the enum, not the module
```

### Solution
Rename the enum to `SwiftGitXRuntime` to eliminate the naming conflict.

After - Clear and unambiguous
```swift
try SwiftGitXRuntime.initialize()
let tag = try #require(references.first as? SwiftGitX.Tag)
// SwiftGitX now correctly resolves to the module
```

### Breaking Changes
Simply rename SwiftGitX to SwiftGitXRuntime.